### PR TITLE
fix: detect & use short ASNs for lsappinfo query

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -76,9 +76,21 @@ function __done_windows_notification -a title -a message
 "
 end
 
+function __done_lsappinfo
+    # from the lsappinfo man page, ASNs can take several forms:
+    # - "ASN:0xAAAA:0xBBBB:" where AAAA and BBBB are the values for an application ASN.
+    # - "0xBBBB" where BBBB are the values from the lower part of an application ASN for which the upper part of the ASN is 0x0
+    # this function attempts to detect the latter case and put the ASN into the proper form for querying lsappinfo
+    set asn (lsappinfo front)
+    if string match -rgq 'ASN:0x0-(?<short_asn>.*):' $asn
+        set asn '0x'$short_asn
+    end
+    lsappinfo info -only bundleID $asn | cut -d '"' -f4
+end
+
 function __done_get_focused_window_id
     if type -q lsappinfo
-        lsappinfo info -only bundleID (lsappinfo front) | cut -d '"' -f4
+        __done_lsappinfo
     else if test -n "$SWAYSOCK"
         and type -q jq
         swaymsg --quiet --type get_tree | jq '.. | objects | select(.focused == true) | .id'


### PR DESCRIPTION
done was not sending notifications on my machine, on the macOS sonoma beta.

i did some digging and it turned out that `lsappinfo` was returning a kind of ASN that cannot be directly used to query for a bundle ID:

```fish
$ lsappinfo front
ASN:0x0-a90a9:
$ lsappinfo info 'ASN:0x0-a90a9:'
$
```

looking at the `lsappinfo` manpage, it turns out that ASN's starting with `0x0-` have to be queried differently:

```fish
$ lsappinfo front
ASN:0x0-a90a9:
$ lsappinfo info '0xa90a9'
"WezTerm" ASN:0x0-a90a9: (in front)
    bundleID="com.github.wez.wezterm"
    bundle path="/Applications/WezTerm.app"
    executable path="/Applications/WezTerm.app/Contents/MacOS/wezterm-gui"
    .. et cetera ..
```

this PR adds a function `__done_lsappinfo` that tries to detect this type of ASN and convert it to the correct form before getting the bundleID:

```fish
$ __done_lsappinfo
com.github.wez.wezterm
```

this fixes the issue for me and i am once again seeing notifications.
it should retain compatibility with the longer style of ASN. i've tested this function manually as best i can to ensure it preserves ASNs in the longer format, however as my machine is not using any of these long ASNs i can't be entirely sure it works end-to-end.